### PR TITLE
Switch diagnostic output to stderr, fix #36

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-kentcdodds": "^12.2.1",
     "husky": "^0.13.3",
     "jest-cli": "^19.0.2",
+    "nps": "^5.0.5",
     "nps-utils": "^1.2.0",
     "opt-cli": "^1.5.1",
     "pify": "^2.3.0",

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -126,7 +126,7 @@ function formatFilesFromGlobs(
 
     function onComplete() {
       if (successes.length) {
-        console.log(
+        console.error(
           messages.success({
             success: chalk.green('success'),
             count: successes.length,
@@ -136,7 +136,7 @@ function formatFilesFromGlobs(
       }
       if (failures.length) {
         process.exitCode = 1
-        console.log(
+        console.error(
           messages.failure({
             failure: chalk.red('failure'),
             count: failures.length,
@@ -145,7 +145,7 @@ function formatFilesFromGlobs(
         )
       }
       if (unchanged.length) {
-        console.log(
+        console.error(
           messages.unchanged({
             unchanged: chalk.gray('unchanged'),
             count: unchanged.length,

--- a/src/format-files.test.js
+++ b/src/format-files.test.js
@@ -23,11 +23,12 @@ test('sanity test', async () => {
   expect(fsMock.readFile).toHaveBeenCalledTimes(6)
   expect(formatMock).toHaveBeenCalledTimes(6)
   expect(fsMock.writeFile).toHaveBeenCalledTimes(0)
-  expect(console.log).toHaveBeenCalledTimes(7)
+  expect(console.log).toHaveBeenCalledTimes(6)
+  expect(console.error).toHaveBeenCalledTimes(1)
   const mockOutput = expect.stringMatching(/MOCK_OUTPUT.*index.js/)
   const successOutput = expect.stringMatching(/success.*6.*files/)
   expect(console.log).toHaveBeenCalledWith(mockOutput)
-  expect(console.log).toHaveBeenCalledWith(successOutput)
+  expect(console.error).toHaveBeenCalledWith(successOutput)
 })
 
 test('glob call inclues an ignore of node_modules', async () => {
@@ -80,11 +81,11 @@ test('handles file errors gracefully', async () => {
   const globs = ['files-with-syntax-errors/*.js', 'src/**/1*.js']
   await formatFiles({_: globs, write: true})
   expect(fsMock.writeFile).toHaveBeenCalledTimes(4)
-  expect(console.log).toHaveBeenCalledTimes(2)
+  expect(console.error).toHaveBeenCalledTimes(4)
   const successOutput = expect.stringMatching(/success.*4.*files/)
   const failureOutput = expect.stringMatching(/failure.*2.*files/)
-  expect(console.log).toHaveBeenCalledWith(successOutput)
-  expect(console.log).toHaveBeenCalledWith(failureOutput)
+  expect(console.error).toHaveBeenCalledWith(successOutput)
+  expect(console.error).toHaveBeenCalledWith(failureOutput)
 })
 
 test('does not print success if there were no successful files', async () => {
@@ -106,15 +107,14 @@ test('logs errors to the console if something goes wrong', async () => {
   const globs = ['eslint-config-error/*.js', 'src/**/2*.js']
   await formatFiles({_: globs, write: true})
   expect(fsMock.writeFile).toHaveBeenCalledTimes(4)
-  expect(console.log).toHaveBeenCalledTimes(2)
+  expect(console.error).toHaveBeenCalledTimes(4)
   const successOutput = expect.stringMatching(/success.*4.*files/)
   const failureOutput = expect.stringMatching(/failure.*2.*files/)
-  expect(console.log).toHaveBeenCalledWith(successOutput)
-  expect(console.log).toHaveBeenCalledWith(failureOutput)
+  expect(console.error).toHaveBeenCalledWith(successOutput)
+  expect(console.error).toHaveBeenCalledWith(failureOutput)
   const errorPrefix = expect.stringMatching(/prettier-eslint-cli.*ERROR/)
   const cliError = expect.stringContaining('eslint-config-error')
   const errorOutput = expect.stringContaining('Some weird eslint config error')
-  expect(console.error).toHaveBeenCalledTimes(2)
   expect(console.error).toHaveBeenCalledWith(
     errorPrefix,
     cliError,
@@ -141,7 +141,7 @@ test('wont save file if contents did not change', async () => {
   expect(fsMock.readFile).toHaveBeenCalledTimes(3)
   expect(fsMock.writeFile).toHaveBeenCalledTimes(0)
   const unchangedOutput = expect.stringMatching(/3.*?files.*?unchanged/)
-  expect(console.log).toHaveBeenCalledWith(unchangedOutput)
+  expect(console.error).toHaveBeenCalledWith(unchangedOutput)
 })
 
 test('allows you to specify an ignore glob', async () => {
@@ -171,7 +171,7 @@ test('wont modify a file if it is eslint ignored', async () => {
     expect.any(Function),
   )
   const ignoredOutput = expect.stringMatching(/success.*1.*file/)
-  expect(console.log).toHaveBeenCalledWith(ignoredOutput)
+  expect(console.error).toHaveBeenCalledWith(ignoredOutput)
 })
 
 test('will modify a file if it is eslint ignored with noIgnore', async () => {
@@ -183,7 +183,7 @@ test('will modify a file if it is eslint ignored with noIgnore', async () => {
   expect(fsMock.readFile).toHaveBeenCalledTimes(4)
   expect(fsMock.writeFile).toHaveBeenCalledTimes(4)
   const ignoredOutput = expect.stringMatching(/success.*4.*files/)
-  expect(console.log).toHaveBeenCalledWith(ignoredOutput)
+  expect(console.error).toHaveBeenCalledWith(ignoredOutput)
 })
 
 test('will not blow up if an .eslintignore cannot be found', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2075,7 +2075,7 @@ event-emitter@~0.3.4:
     d "~0.1.1"
     es5-ext "~0.10.7"
 
-event-stream@^3.3.0:
+event-stream@^3.3.0, event-stream@~3.3.0:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
   dependencies:
@@ -2894,6 +2894,10 @@ is-number@^2.0.2, is-number@^2.1.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -3549,7 +3553,7 @@ lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.11.2, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
+lodash@^4.0.0, lodash@^4.11.2, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3604,7 +3608,7 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-manage-path@2.0.0:
+manage-path@2.0.0, manage-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/manage-path/-/manage-path-2.0.0.tgz#f4cf8457b926eeee2a83b173501414bc76eb9597"
 
@@ -3962,6 +3966,23 @@ nps-utils@^1.2.0:
     opn-cli "^3.1.0"
     rimraf "^2.6.1"
 
+nps@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/nps/-/nps-5.0.5.tgz#52fee585d650c8aa093936e78d78d036899f2ea8"
+  dependencies:
+    arrify "^1.0.1"
+    chalk "^1.1.3"
+    common-tags "^1.4.0"
+    find-up "^2.1.0"
+    js-yaml "^3.7.0"
+    lodash "^4.17.4"
+    manage-path "^2.0.0"
+    prefix-matches "^0.0.9"
+    readline-sync "^1.4.6"
+    spawn-command-with-kill "^1.0.0"
+    type-detect "^4.0.0"
+    yargs "^6.6.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -4240,6 +4261,13 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
+prefix-matches@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/prefix-matches/-/prefix-matches-0.0.9.tgz#5887019e2b9566b38917f7529b6ce0fc2c72d68c"
+  dependencies:
+    is-object "^1.0.1"
+    starts-with "^1.0.2"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -4306,6 +4334,12 @@ proto-list@~1.2.1:
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+
+ps-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -4423,6 +4457,10 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
+
+readline-sync@^1.4.6:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.7.tgz#001bfdd4c06110c3c084c63bf7c6a56022213f30"
 
 readline2@^1.0.1:
   version "1.0.1"
@@ -4834,6 +4872,13 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
+spawn-command-with-kill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/spawn-command-with-kill/-/spawn-command-with-kill-1.0.0.tgz#803ad79f2f56e44dd926183768aac2faec7d0ce6"
+  dependencies:
+    ps-tree "^1.1.0"
+    spawn-command "^0.0.2-1"
+
 spawn-command@0.0.2-1:
   version "0.0.2-1"
   resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
@@ -4887,6 +4932,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+starts-with@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/starts-with/-/starts-with-1.0.2.tgz#16793a729d89d4cf3d4fb2eda2f908ae357f196f"
 
 stealthy-require@^1.0.0:
   version "1.0.0"
@@ -5177,6 +5226,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.0.tgz#62053883542a321f2f7b25746dc696478b18ff6b"
 
 typedarray@^0.0.6:
   version "0.0.6"
@@ -5475,7 +5528,7 @@ yargs@^4.7.0:
     y18n "^3.2.1"
     yargs-parser "^2.4.1"
 
-yargs@^6.0.0, yargs@^6.3.0:
+yargs@^6.0.0, yargs@^6.3.0, yargs@^6.6.0:
   version "6.6.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
   dependencies:


### PR DESCRIPTION
Separate the content output and the diagnostic output.
Allows users to redirect the output separately from the diagnostic output.

I’ve searched the codebase and this is the only file containing relevant `console.log`s.

Note that you may consider this a compatibility breaking change. A client expecting a piece of diagnostic output on `stdout` won’t find it there. Although given that the content was outputted together with the diagnositc messages, it seems messy to use, so perhaps the users reporting the issue were the first to try. The call is yours.