### PR TITLE
feat(cli): add support for prettier options

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -72,6 +72,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "Gandem",
+      "name": "Gandem",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/11560964?v=3",
+      "profile": "https://github.com/Gandem",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CLI for [`prettier-eslint`][prettier-eslint]
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -158,6 +158,15 @@ An alternative approach is to use different tools for different concerns. If you
 argument `--pretter-last`, it will run `eslint --fix` first, then `prettier`. This allows you to
 use `eslint` to look for bugs and/or bad practices, and use `prettier` to enforce code style.
 
+#### --prettier
+ 
+Passes prettier configuration options to prettier-eslint, such as `trailingComma` or `singleQuote`,
+using the dot-notation.
+
+For example: `prettier-eslint --prettier.trailing-comma es5`
+
+The options supported are the same as [prettier-eslint](https://github.com/prettier/prettier-eslint#prettieroptions-object)
+
 ## Related
 
 - [prettier-eslint](https://github.com/prettier/prettier-eslint) - the core package
@@ -170,6 +179,7 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/prettier/prettier-eslint-cli/commits?author=kentcdodds) [📖](https://github.com/prettier/prettier-eslint-cli/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/prettier/prettier-eslint-cli/commits?author=kentcdodds) | [<img src="https://avatars3.githubusercontent.com/u/3266363?v=3" width="100px;"/><br /><sub>Adam Harris</sub>](https://github.com/aharris88)<br />[💻](https://github.com/prettier/prettier-eslint-cli/commits?author=aharris88) [📖](https://github.com/prettier/prettier-eslint-cli/commits?author=aharris88) 👀 | [<img src="https://avatars.githubusercontent.com/u/622118?v=3" width="100px;"/><br /><sub>Eric McCormick</sub>](https://ericmccormick.io)<br />👀 | [<img src="https://avatars.githubusercontent.com/u/12389411?v=3" width="100px;"/><br /><sub>Joel Sequeira</sub>](https://github.com/joelseq)<br />[📖](https://github.com/prettier/prettier-eslint-cli/commits?author=joelseq) | [<img src="https://avatars.githubusercontent.com/u/103008?v=3" width="100px;"/><br /><sub>Frank Taillandier</sub>](https://frank.taillandier.me)<br /> | [<img src="https://avatars3.githubusercontent.com/u/292365?v=3" width="100px;"/><br /><sub>Adam Stankiewicz</sub>](http://sheerun.net)<br />[💻](https://github.com/prettier/prettier-eslint-cli/commits?author=sheerun) | [<img src="https://avatars3.githubusercontent.com/u/487068?v=3" width="100px;"/><br /><sub>Stephen John Sorensen</sub>](http://www.stephenjohnsorensen.com/)<br />[💻](https://github.com/prettier/prettier-eslint-cli/commits?author=spudly) |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/11560964?v=3" width="100px;"/><br /><sub>Gandem</sub>](https://github.com/Gandem)<br />[💻](https://github.com/prettier/prettier-eslint-cli/commits?author=Gandem) [⚠️](https://github.com/prettier/prettier-eslint-cli/commits?author=Gandem) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "babel-runtime": "^6.23.0",
+    "camelcase-keys": "^4.1.0",
     "chalk": "^1.1.3",
     "common-tags": "^1.4.0",
     "find-up": "^2.1.0",

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -26,25 +26,25 @@ const logger = getLogger({prefix: 'prettier-eslint-cli'})
 
 export default formatFilesFromArgv
 
-function formatFilesFromArgv(
-  {
-    _: fileGlobs,
-    logLevel = logger.getLevel(),
-    stdin,
-    write,
-    eslintPath,
-    prettierPath,
-    ignore: ignoreGlobs = [],
-    eslintIgnore: applyEslintIgnore = true,
-    prettierLast,
-  },
-) {
+function formatFilesFromArgv({
+  _: fileGlobs,
+  logLevel = logger.getLevel(),
+  stdin,
+  write,
+  eslintPath,
+  prettierPath,
+  ignore: ignoreGlobs = [],
+  eslintIgnore: applyEslintIgnore = true,
+  prettierLast,
+  prettier,
+}) {
   logger.setLevel(logLevel)
   const prettierESLintOptions = {
     logLevel,
     eslintPath,
     prettierPath,
     prettierLast,
+    prettierOptions: prettier,
   }
   const cliOptions = {write}
   if (stdin) {

--- a/src/format-files.test.js
+++ b/src/format-files.test.js
@@ -135,6 +135,16 @@ test('forwards prettierLast onto prettier-eslint', async () => {
   )
 })
 
+test('forwards prettierOptions onto prettier-eslint', async () => {
+  await formatFiles({
+    _: ['src/**/1*.js'],
+    prettier: {trailingComma: 'es5'},
+  })
+  expect(formatMock).toHaveBeenCalledWith(
+    expect.objectContaining({prettierOptions: {trailingComma: 'es5'}}),
+  )
+})
+
 test('wont save file if contents did not change', async () => {
   const fileGlob = 'no-change/*.js'
   await formatFiles({_: [fileGlob], write: true})

--- a/src/parser.js
+++ b/src/parser.js
@@ -3,6 +3,8 @@ import findUp from 'find-up'
 import yargs from 'yargs'
 import {oneLine} from 'common-tags'
 import arrify from 'arrify'
+import camelcaseKeys from 'camelcase-keys'
+import chalk from 'chalk'
 
 const parser = yargs
   .usage('Usage: $0 <globs>... [--option-1 option-1-value --option-2]')
@@ -54,6 +56,12 @@ const parser = yargs
       default: false,
       type: 'boolean',
     },
+    prettier: {
+      describe: oneLine`
+          Prettier configuration options 
+          to be passed to prettier-eslint
+          using dot-notation`,
+    },
     // TODO: if we allow people to to specify a config path,
     // we need to read that somehow. These can come invarious
     // formats and we'd have to work out `extends` somehow as well.
@@ -62,12 +70,18 @@ const parser = yargs
     // eslintConfigPath: {
     //   describe: 'Path to the eslint config to use for eslint --fix',
     // },
-    // TODO: would this be just a JSON file? There's never going to be
-    // a `.prettierrc`: https://github.com/jlongster/prettier/issues/154
-    // so we'll have to be careful how we do this (if we do it at all).
-    // prettierOptions: {
-    //   describe: 'Path to the prettier config to use',
-    // },,
+  })
+  .coerce('prettier', config => {
+    if (typeof config === 'object') {
+      return camelcaseKeys(config)
+    } else {
+      throw Error(
+        chalk.red(
+          oneLine`You should use dot-notation with 
+          the --prettier flag, for example, --prettier.singleQuote`,
+        ),
+      )
+    }
   })
   .strict()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1195,6 +1195,14 @@ camelcase-keys@^2.0.0:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
 
+camelcase-keys@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.1.0.tgz#214d348cc5457f39316a2c31cc3e37246325e73f"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -1206,6 +1214,10 @@ camelcase@^2.0.0:
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caniuse-db@^1.0.30000624:
   version "1.0.30000624"
@@ -3616,6 +3628,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
@@ -4378,6 +4394,10 @@ querystring-es3@^0.2.0:
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+
+quick-lru@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.0.0.tgz#7fa80304ab72c1f81cef738739cd47d7cc0c8bff"
 
 randomatic@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
This adds support for prettier options using the --prettier flag. We can pass options by using the
"dot" notation : --prettier.trailingComma es5, for example. It supports both snakecase and camelcase config, so it resembles more to prettier options (it accepts --prettier.trailing-commas es5)

Fixes #45.

My biggest doubt with what I did is using the `"--prettier"` flag. I hesitated with `"--prettier-config"` or `"--prettierOptions"` but it would make the flag a little longer ! Please tell me what's your opinion on this 😃