### PR TITLE
Implement the --list-different option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ itself (a common use-case) then add `--write`. You should quote your globs, othe
 > **NOTE:** It is recommended that you keep your files under source control and committed
 > before running `prettier-eslint --write` as it will overwrite your files!
 
+#### --list-different
+
+Instead of printing the formatted version of the files to the terminal, `prettier-eslint` will log the name of the files that are different from the expected formatting. This can be usefull when using `prettier-eslint` in a version control system hook to inform the committer which files need to be formatted.
+
 #### --stdin
 
 Accept input via `stdin`. For example:

--- a/cli-test/tests/index.js
+++ b/cli-test/tests/index.js
@@ -67,6 +67,16 @@ test('formats files and outputs to stdout', async () => {
   )
 })
 
+test('list different files with the --list-different option', async () => {
+  // can't just do the testOutput function here because
+  // the output is in an undeterministic order
+  const stdout = await runPrettierESLintCLI(
+    'cli-test/fixtures/stdout*.js --list-different --no-eslint-ignore',
+  )
+  expect(stdout).toContain('cli-test/fixtures/stdout1.js')
+  expect(stdout).toContain('cli-test/fixtures/stdout2.js')
+})
+
 test('accepts stdin of code', async () => {
   const stdin = 'echo "console.log(   window.baz , typeof [] );  "'
   const stdout = await runPrettierESLintCLI('--stdin', stdin)

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -179,15 +179,16 @@ function formatFile(filePath, prettierESLintOptions, cliOptions) {
   let format$ = rxReadFile(filePath, 'utf8').map(text => {
     fileInfo.text = text
     fileInfo.formatted = format({text, filePath, ...prettierESLintOptions})
+    fileInfo.unchanged = fileInfo.text === fileInfo.formatted
     return fileInfo
   })
 
   if (cliOptions.write) {
     format$ = format$.mergeMap(info => {
-      if (info.text === info.formatted) {
-        return Rx.Observable.of(Object.assign(fileInfo, {unchanged: true}))
+      if (info.unchanged) {
+        return Rx.Observable.of(info)
       } else {
-        return rxWriteFile(filePath, info.formatted).map(() => fileInfo)
+        return rxWriteFile(filePath, info.formatted).map(() => info)
       }
     })
   } else {

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -29,6 +29,7 @@ export default formatFilesFromArgv
 function formatFilesFromArgv({
   _: fileGlobs,
   logLevel = logger.getLevel(),
+  listDifferent,
   stdin,
   write,
   eslintPath,
@@ -46,7 +47,7 @@ function formatFilesFromArgv({
     prettierLast,
     prettierOptions: prettier,
   }
-  const cliOptions = {write}
+  const cliOptions = {write, listDifferent}
   if (stdin) {
     return formatStdin(prettierESLintOptions)
   } else {
@@ -190,6 +191,13 @@ function formatFile(filePath, prettierESLintOptions, cliOptions) {
       } else {
         return rxWriteFile(filePath, info.formatted).map(() => info)
       }
+    })
+  } else if (cliOptions.listDifferent) {
+    format$ = format$.map(info => {
+      if (!info.unchanged) {
+        console.log(info.filePath)
+      }
+      return info
     })
   } else {
     format$ = format$.map(info => {

--- a/src/format-files.test.js
+++ b/src/format-files.test.js
@@ -11,6 +11,7 @@ jest.mock('fs')
 beforeEach(() => {
   process.stdout.write = jest.fn()
   console.error = jest.fn()
+  console.log = jest.fn()
   formatMock.mockClear()
   fsMock.writeFile.mockClear()
   fsMock.readFile.mockClear()
@@ -218,4 +219,26 @@ test('will not blow up if an .eslintignore cannot be found', async () => {
   } finally {
     findUpMock.sync = originalSync
   }
+})
+
+test('will list different files', async () => {
+  await formatFiles({
+    _: ['src/**/1*.js', 'src/**/no-change*.js'],
+    listDifferent: true,
+  })
+  expect(fsMock.readFile).toHaveBeenCalledTimes(7)
+  expect(fsMock.writeFile).toHaveBeenCalledTimes(0)
+
+  const unchangedOutput = expect.stringMatching(/3.*files were.*unchanged/)
+  const successOutput = expect.stringMatching(/success.*4.*files/)
+  expect(console.error).toHaveBeenCalledTimes(2)
+  expect(console.error).toHaveBeenCalledWith(unchangedOutput)
+  expect(console.error).toHaveBeenCalledWith(successOutput)
+
+  const path = '/Users/fredFlintstone/Developer/top-secret/footless-carriage/'
+  expect(console.log).toHaveBeenCalledTimes(4)
+  expect(console.log).toHaveBeenCalledWith(`${path}stop/log.js`)
+  expect(console.log).toHaveBeenCalledWith(`${path}stop/index.js`)
+  expect(console.log).toHaveBeenCalledWith(`${path}index.js`)
+  expect(console.log).toHaveBeenCalledWith(`${path}start.js`)
 })

--- a/src/format-files.test.js
+++ b/src/format-files.test.js
@@ -154,6 +154,15 @@ test('wont save file if contents did not change', async () => {
   expect(console.error).toHaveBeenCalledWith(unchangedOutput)
 })
 
+test('will report unchanged files even if not written', async () => {
+  const fileGlob = 'no-change/*.js'
+  await formatFiles({_: [fileGlob], write: false})
+  expect(fsMock.readFile).toHaveBeenCalledTimes(3)
+  expect(fsMock.writeFile).toHaveBeenCalledTimes(0)
+  const unchangedOutput = expect.stringMatching(/3.*?files.*?unchanged/)
+  expect(console.error).toHaveBeenCalledWith(unchangedOutput)
+})
+
 test('allows you to specify an ignore glob', async () => {
   const ignore = ['src/ignore/thing', 'src/ignore/otherthing']
   const fileGlob = 'src/**/1*.js'

--- a/src/parser.js
+++ b/src/parser.js
@@ -31,6 +31,14 @@ const parser = yargs
         (can use --no-eslint-ignore to disable this)
       `,
     },
+    'list-different': {
+      default: false,
+      type: 'boolean',
+      describe: oneLine`
+        Print filenames of files that are different
+        from Prettier + Eslint formatting.
+      `,
+    },
     eslintPath: {
       default: getPathInHostNodeModules('eslint'),
       describe: 'The path to the eslint module to use',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: In `prettier`, the `--list-different` prints the files that would need to be changed to match the `prettier` style. This implements the same option for `prettier-eslint-cli`. 

<!-- Why are these changes necessary? -->
**Why**: This feature is really usefull for VCS hooks (or maybe CI) to tell the dev which files need to be formated before commiting.

<!-- How were these changes implemented? -->
**How**: Pretty trivial: add a CLI option, change the output according to this option.


<!-- feel free to add additional comments -->
Note: I took the opportunity to harmonize the `unchanged/success` messages when formating files without `--write`. It seemed strange to me to have different outputs at this level. But I can remove this commit if it is unwanted.