### PR TITLE
Removed default values for eslintPath and prettierPath

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -49,7 +49,6 @@ const parser = yargs
     },
     // allow `--eslint-path` and `--eslintPath`
     'eslint-path': {
-      default: getPathInHostNodeModules('eslint'),
       describe: 'The path to the eslint module to use',
       coerce: coercePath,
     },
@@ -61,7 +60,6 @@ const parser = yargs
     // allow `--prettier-path` and `--prettierPath`
     'prettier-path': {
       describe: 'The path to the prettier module to use',
-      default: getPathInHostNodeModules('prettier'),
       coerce: coercePath,
     },
     ignore: {
@@ -159,23 +157,6 @@ const parser = yargs
   .strict()
 
 export default parser
-
-function getPathInHostNodeModules(module) {
-  logger.debug(`Looking for a local installation of the module "${module}"`)
-  const modulePath = findUp.sync(`node_modules/${module}`)
-
-  if (modulePath) {
-    return modulePath
-  }
-  logger.debug(
-    oneLine`
-      Local installation of "${module}" not found,
-      looking again starting in "${__dirname}"
-    `,
-  )
-
-  return findUp.sync(`node_modules/${module}`, {cwd: __dirname})
-}
 
 function coercePath(input) {
   return path.isAbsolute(input) ? input : path.join(process.cwd(), input)

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,11 +1,7 @@
 import path from 'path'
-import getLogger from 'loglevel-colored-level-prefix'
-import findUp from 'find-up'
 import yargs from 'yargs'
 import {oneLine, stripIndent} from 'common-tags'
 import arrify from 'arrify'
-
-const logger = getLogger({prefix: 'prettier-eslint-cli'})
 
 const parser = yargs
   .usage(


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Removed default values for eslintPath and prettierPath. This improves compatibility for scenarios where not all dependencies of a project reside in a completely flat node_modules folder (the most common cause for this would be that npm 2.x is still being used)

<!-- Why are these changes necessary? -->
**Why**:
These values are not required by prettier-eslint-cli itself. They are only passed to prettier-eslint, and even then, they're optional. When using npm >3, whether we pass the value or not is all the same - the node_modules directory is flattened and both prettier and eslint will reside in the same node_modules folder no matter which other module depends on it. But for npm 2.x, the default assumptions don't work.

It's true that people should be running npm >3 today, but for CI scenarios, npm 2 or downwards can still be used in combination with node 4.x (which is going to be supported for a long time still).

In any case, not passing a default value seems to align better with node's `require` algorithm - it will start where it needs to start (in this case wherever the prettier-eslint dependency has been installed), and then mimick find-up's logic.

<!-- How were these changes implemented? -->
**How**:
I simply removed the default values and the associated helper function.

<!-- feel free to add additional comments -->
