### PR TITLE
feat(cli): add the --stdin-filepath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Options:
   --write                  Edit the file in-place (beware!)
                                                       [boolean] [default: false]
   --stdin                  Read input via stdin       [boolean] [default: false]
+  --stdin-filepath         Path to the file to pretend that stdin comes from.
   --eslint-ignore          Only format matching files even if they are not
                            ignored by .eslintignore. (can use --no-eslint-ignore
                            to disable this)            [boolean] [default: true]

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -35,6 +35,7 @@ function formatFilesFromArgv({
   logLevel = logger.getLevel(),
   listDifferent,
   stdin,
+  stdinFilepath,
   write,
   eslintPath,
   prettierPath,
@@ -63,7 +64,7 @@ function formatFilesFromArgv({
 
   const cliOptions = {write, listDifferent}
   if (stdin) {
-    return formatStdin(prettierESLintOptions)
+    return formatStdin({filePath: stdinFilepath, ...prettierESLintOptions})
   } else {
     return formatFilesFromGlobs(
       fileGlobs,

--- a/src/parser.js
+++ b/src/parser.js
@@ -26,6 +26,10 @@ const parser = yargs
       describe: 'Read input via stdin',
       type: 'boolean',
     },
+    'stdin-filepath': {
+      describe: 'Path to the file to pretend that stdin comes from.',
+      coerce: coercePath,
+    },
     'eslint-ignore': {
       default: true,
       type: 'boolean',


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Add the `--stdin-filepath` option.

<!-- Why are these changes necessary? -->
**Why**:

This option is really usefull when using prettier-eslint-cli inside text editor plugins, to let prettier-eslint discover the correct eslintrc configuration for the given file.

<!-- How were these changes implemented? -->
**How**:

It's pretty straightforward:
* declared the new option for the argument parser
* use its value when running pretierr-eslint-cli on stdin.

<!-- feel free to add additional comments -->


Related:
* https://github.com/prettier/prettier-eslint-cli/issues/95
* https://github.com/sbdchd/neoformat/issues/112
* https://github.com/prettier/prettier-emacs/pull/10#issuecomment-325257171