### PR TITLE
test: fix test.cli not running any test file

### DIFF
--- a/cli-test/jest.config.json
+++ b/cli-test/jest.config.json
@@ -1,12 +1,6 @@
 {
-  "roots": [
-    "<rootDir>/cli-test/tests"
-  ],
+  "roots": ["<rootDir>/tests"],
   "testEnvironment": "jest-environment-node",
-  "testPathIgnorePatterns": [
-    "/node_modules/",
-    "/helpers/",
-    "/fixtures/"
-  ],
+  "testPathIgnorePatterns": ["/node_modules/", "/helpers/", "/fixtures/"],
   "testRegex": "^.*.js$"
 }


### PR DESCRIPTION
**What**:

The cli-test suite did not run any test file because of an invalid root path configuration.

See the [last build](https://travis-ci.org/prettier/prettier-eslint-cli/builds/280502772#L2477-L2483) logs for example.

**Why**:

It's nice to have cli tests working 😄 

**How**:

Just fixed the tests root path in the jest configuration file.