### PR TITLE
Fix rxjs import

### DIFF
--- a/src/format-files.js
+++ b/src/format-files.js
@@ -2,7 +2,7 @@
 import path from 'path'
 import fs from 'fs'
 import glob from 'glob'
-import Rx from 'rxjs/Rx'
+import * as Rx from 'rxjs'
 import format from 'prettier-eslint'
 import chalk from 'chalk'
 import getStdin from 'get-stdin'
@@ -105,8 +105,7 @@ function formatFilesFromGlobs(
     const successes = []
     const failures = []
     const unchanged = []
-    Rx.Observable
-      .from(fileGlobs)
+    Rx.Observable.from(fileGlobs)
       .mergeMap(
         getFilesFromGlob.bind(null, ignoreGlobs, applyEslintIgnore),
         null,
@@ -270,4 +269,3 @@ function getIsIgnored(filename) {
   instance.add(ignoreLines)
   return instance.ignores.bind(instance)
 }
-


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: [`rxjs` uses named exports](https://github.com/ReactiveX/rxjs/blob/master/src/Rx.ts), but `prettier-eslint-cli` imports it as a `default`.

<!-- Why are these changes necessary? -->
**Why**: `prettier-eslint-cli` doesn't work because it throws with a `TypeError: Cannot read property 'Observable' of undefined`.

<!-- How were these changes implemented? -->
**How**: By replacing a default import with a wildcard one.


<!-- feel free to add additional comments -->
Tested against `rxjs@5.3.0` and `rxjs@5.5+`.