### PR TITLE
Use eslint path to choose where to load eslint's config library

### DIFF
--- a/src/format-files.js
+++ b/src/format-files.js
@@ -1,5 +1,6 @@
 /* eslint no-console:0 */
 /* eslint complexity:[1, 7] */
+/* eslint-disable import/no-dynamic-require */
 import path from "path";
 import fs from "fs";
 import glob from "glob";
@@ -12,9 +13,6 @@ import findUp from "find-up";
 import memoize from "lodash.memoize";
 import indentString from "indent-string";
 import getLogger from "loglevel-colored-level-prefix";
-import ConfigFile from "eslint/lib/config/config-file";
-import Linter from "eslint/lib/linter";
-import Config from "eslint/lib/config";
 import * as messages from "./messages";
 
 const LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;
@@ -66,6 +64,11 @@ function formatFilesFromArgv({
     prettierLast,
     prettierOptions
   };
+
+  const eslintLoadPath = eslintPath || "eslint";
+  const ConfigFile = require(`${eslintLoadPath}/lib/config/config-file`);
+  const Linter = require(`${eslintLoadPath}/lib/linter`);
+  const Config = require(`${eslintLoadPath}/lib/config`);
 
   if (eslintConfigPath) {
     const configContext = new Config({}, new Linter());


### PR DESCRIPTION
eslint uses a pretty simple algorithm to work out where the 'project' lives - and node_modules for plugins/configs are loaded relative to - [`__dirname + '/../../..'`](https://github.com/eslint/eslint/blob/b201e17bba079c50a7b48e25a349d6e94e7c84f8/lib/config/config-file.js#L330).

This means using prettier-eslint-cli's own version of eslint means plugins/configs cannot be loaded. Using the eslint install from `eslintPath` passed in is more consistent, and provides a way to use config/plugins from node_modules.

Fixes #127