### PR TITLE
update to eslint 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "camelcase-keys": "^4.1.0",
     "chalk": "2.3.0",
     "common-tags": "^1.4.0",
-    "eslint": "^4.5.0",
+    "eslint": "5.15.3",
     "find-up": "^2.1.0",
     "get-stdin": "^5.0.1",
     "glob": "^7.1.1",


### PR DESCRIPTION
update to eslint.

I want to use it with '@typescript-eslint/parser'.
but, in version 4.0 of eslint, an error occurs.