### PR TITLE
Add prepare script, to allow installation from Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prettier-eslint": "dist/index.js"
   },
   "scripts": {
+    "prepare": "nps build",
     "start": "nps",
     "test": "nps test",
     "precommit": "lint-staged && opt --in pre-commit --exec \"npm start validate\""


### PR DESCRIPTION
This fixes `npm i prettier/prettier-eslint-cli`, which pulls the package from GitHub instead of NPM. Before:

```console
$ npm i prettier/prettier-eslint-cli
npm WARN deprecated messageformat@2.3.0: Package renamed as '@messageformat/core', see messageformat.github.io for more details. 'messageformat' will eventually provide a polyfill for Intl.MessageFormat, once it's been defined by Unicode & ECMA.
npm ERR! code ENOENT
npm ERR! syscall chmod
npm ERR! path /tmp/test/node_modules/prettier-eslint-cli/dist/index.js
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, chmod '/tmp/test/node_modules/prettier-eslint-cli/dist/index.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
```

After:

```console
$ npm i andersk/prettier-eslint-cli#f836fdbed2acd14d34c3548d9bf085647e05557f
npm WARN deprecated messageformat@2.3.0: Package renamed as '@messageformat/core', see messageformat.github.io for more details. 'messageformat' will eventually provide a polyfill for Intl.MessageFormat, once it's been defined by Unicode & ECMA.

added 196 packages, and audited 197 packages in 48s

8 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

$ npx prettier-eslint-cli --version
0.0.0-development
```