### PR TITLE
WIP: update eslintrc for validation testing

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -249,6 +249,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "mattbrannon",
+      "name": "Matt Brannon",
+      "avatar_url": "https://avatars.githubusercontent.com/u/36570183?v=4",
+      "profile": "https://mattbrannon.dev/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 const config = {
-  extends: ['kentcdodds', 'kentcdodds/jest'],
+  parser: '@babel/eslint-parser',
   rules: {
     quotes: ['error', 'single', { avoidEscape: true }],
     'arrow-parens': ['error', 'as-needed'],
@@ -10,10 +10,10 @@ const config = {
       {
         anonymous: 'never',
         named: 'never',
-        asyncArrow: 'always'
-      }
-    ]
-  }
+        asyncArrow: 'always',
+      },
+    ],
+  },
 };
 
 module.exports = config;

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Thanks goes to these people ([emoji key][emojis]):
     <td align="center"><a href="http://danielwilhelmsen.com"><img src="https://avatars3.githubusercontent.com/u/1758049?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Daniel Wilhelmsen</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint-cli/commits?author=dpwilhelmsen" title="Code">💻</a> <a href="#maintenance-dpwilhelmsen" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://github.com/gwhitney"><img src="https://avatars.githubusercontent.com/u/3825429?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Glen Whitney</b></sub></a><br /><a href="#maintenance-gwhitney" title="Maintenance">🚧</a></td>
     <td align="center"><a href="https://campcode.dev/"><img src="https://avatars.githubusercontent.com/u/10620169?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Rebecca Vest</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint-cli/commits?author=idahogurl" title="Code">💻</a></td>
+    <td align="center"><a href="https://mattbrannon.dev/"><img src="https://avatars.githubusercontent.com/u/36570183?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Matt Brannon</b></sub></a><br /><a href="https://github.com/prettier/prettier-eslint-cli/commits?author=mattbrannon" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.5",
+    "@babel/eslint-parser": "^7.18.9",
     "@babel/node": "^7.4.5",
     "@babel/preset-env": "^7.4.5",
     "@babel/register": "^7.4.4",
@@ -53,7 +54,6 @@
     "ajv": "^6.10.0",
     "all-contributors-cli": "^6.7.0",
     "babel-jest": "^24.8.0",
-    "eslint-config-kentcdodds": "^20.2.0",
     "husky": "^2.4.1",
     "jest": "^24.8.0",
     "jest-cli": "^24.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-// eslint-disable-next-line import/no-unassigned-import
 import './add-exception-handler'; // want to do this first
 import getLogger from 'loglevel-colored-level-prefix';
 import parser from './parser';

--- a/src/message.test.js
+++ b/src/message.test.js
@@ -1,37 +1,36 @@
-/*eslint import/namespace: [2, { allowComputed: true }]*/
 import * as messages from './messages';
 
 const tests = {
   success: [
     {
       input: { success: 'success', count: 1, countString: '1String' },
-      output: 'success formatting 1String file with prettier-eslint'
+      output: 'success formatting 1String file with prettier-eslint',
     },
     {
       input: { success: 'success', count: 3, countString: '3String' },
-      output: 'success formatting 3String files with prettier-eslint'
-    }
+      output: 'success formatting 3String files with prettier-eslint',
+    },
   ],
   failure: [
     {
       input: { failure: 'failure', count: 1, countString: '1String' },
-      output: 'failure formatting 1String file with prettier-eslint'
+      output: 'failure formatting 1String file with prettier-eslint',
     },
     {
       input: { failure: 'failure', count: 3, countString: '3String' },
-      output: 'failure formatting 3String files with prettier-eslint'
-    }
+      output: 'failure formatting 3String files with prettier-eslint',
+    },
   ],
   unchanged: [
     {
       input: { unchanged: 'unchanged', count: 1, countString: '1String' },
-      output: '1String file was unchanged'
+      output: '1String file was unchanged',
     },
     {
       input: { unchanged: 'unchanged', count: 3, countString: '3String' },
-      output: '3String files were unchanged'
-    }
-  ]
+      output: '3String files were unchanged',
+    },
+  ],
 };
 
 Object.keys(tests).forEach(messageKey => {


### PR DESCRIPTION
I recently forked this project and wanted to try tackling some issues. However, I ran into problems with the validation script `npm start validate`. The first set of tests ran normally but the second set, which internally runs `nps test.cli` failed in 4 out of 7 tests with the error message `Environment key \"jest/globals\" is unknown` which the package `eslint-config-kentcdodds` uses in it's configuration.

![Screen Shot 2022-07-31 at 8 48 42 AM](https://user-images.githubusercontent.com/36570183/182029496-02637eec-6334-430d-872f-e9af384e9c94.png)


Removing the `extends` field and adding `@babel/eslint-parser` as a parser allows the tests to run normally. 

Specifically this PR does the following:
- Adds `@babel/eslint-parser` to dev dependencies 
- Specifies `@babel/eslint-parser` as parser in `.eslintrc.js`
- Removes `eslint-config-kentcdodds` as a dev dependency
- Removes some inline eslint comments

Please let me know if there's anything that needs to change. This is quick fix that allows the tests to run to completion without blowing up halfway through. I assume that Kent knows what he's doing in terms of his eslint + jest configuration but, at the moment, it appears to be causing an issue. It's unclear to me exactly where in the chain the problem occurs.