### PR TITLE
feat: make the cli work with/without `prettier-eslint` peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,16 @@
     "JounQin (https://www.1stG.me) <admin@1stg.me>"
   ],
   "license": "MIT",
+  "peerDependencies": {
+    "prettier-eslint": "*"
+  },
+  "peerDependenciesMeta": {
+    "prettier-eslint": {
+      "optional": true
+    }
+  },
   "dependencies": {
+    "@prettier/eslint": "npm:prettier-eslint@^15.0.1",
     "arrify": "^2.0.1",
     "boolify": "^1.0.1",
     "camelcase-keys": "^7.0.2",
@@ -42,7 +51,6 @@
     "lodash.memoize": "^4.1.2",
     "loglevel-colored-level-prefix": "^1.0.0",
     "messageformat": "^2.3.0",
-    "prettier-eslint": "^15.0.1",
     "rxjs": "^7.5.6",
     "yargs": "^13.1.1"
   },

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -5,7 +5,6 @@ import fs from 'fs';
 import glob from 'glob';
 import { bindNodeCallback, from, of } from 'rxjs';
 import { catchError, concatAll, distinct, map, mergeMap } from 'rxjs/operators';
-import format from 'prettier-eslint';
 import chalk from 'chalk';
 import getStdin from 'get-stdin';
 import nodeIgnore from 'ignore';
@@ -13,6 +12,7 @@ import findUp from 'find-up';
 import memoize from 'lodash.memoize';
 import indentString from 'indent-string';
 import getLogger from 'loglevel-colored-level-prefix';
+import format from './prettier-eslint';
 import * as messages from './messages';
 
 const LINE_SEPERATOR_REGEX = /(\r|\n|\r\n)/;

--- a/src/format-files.test.js
+++ b/src/format-files.test.js
@@ -1,10 +1,10 @@
 /* eslint no-console:0 */
 import fsMock from 'fs';
 import findUpMock from 'find-up';
-import formatMock from 'prettier-eslint';
 import globMock from 'glob';
 import mockGetStdin from 'get-stdin';
 import getLogger from 'loglevel-colored-level-prefix';
+import formatMock from './prettier-eslint';
 import formatFiles from './format-files';
 
 jest.mock('fs');

--- a/src/prettier-eslint.js
+++ b/src/prettier-eslint.js
@@ -1,0 +1,17 @@
+const getLogger = require('loglevel-colored-level-prefix');
+
+const logger = getLogger({ prefix: 'prettier-eslint-cli' });
+
+try {
+  // if `prettier-eslint` is installed by the user manually
+  module.exports = require('prettier-eslint');
+} catch (err) /* istanbul ignore next */ {
+  logger.info('We detected that no `prettier-eslint` is installed.');
+  logger.info('We will use our internal fallback one instead.');
+  logger.info(
+    'You can install `prettier-eslint` as dependency to skip this message.'
+  );
+
+  // it is an internal dependency using `prettier-eslint` as fallback
+  module.exports = require('@prettier/eslint');
+}

--- a/test/tests/cli.spec.js
+++ b/test/tests/cli.spec.js
@@ -24,7 +24,7 @@ test('help outputs usage information and flags', async () => {
   // terminal I think)...
   const stdout = await runPrettierESLintCLI('--help');
   expect(stdout).toMatch(/Usage:.*?<globs>.../);
-  expect(stdout).toContain('Options:\n');
+  expect(stdout).toContain('Valid options:\n');
   // just a sanity check.
   // If it's ever longer than 2000 then we've probably got a problem...
   // eslint-disable-next-line jest/no-conditional-in-test


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

close #144, close #436

BREAKING CHANGE: bump all upgradable (dev)Dependencies except pure ESM

(WTF `semantic-release`...)

We must be careful on merging...

`BREAKING CHANGE:` token must be in the footer of the commit (which is stupid again and again)

<!-- Why are these changes necessary? -->

**Why**:

close#144

<!-- How were these changes implemented? -->


close #144

<!-- Why are these changes necessary? -->

**Why**:

close#144

<!-- How were these changes implemented? -->

**How**:

mark `prettier-eslint` as optional peer dependency, and fallback to internal `@prettier/eslint` which actually pointing to `prettier-eslint`

<!-- feel free to add additional comments -->
