### PR TITLE
docs: cleanup build and sponsors badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ CLI for [`prettier-eslint`][prettier-eslint]
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][license]
 
+[![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/prettier?style=flat-square)](https://opencollective.com/prettier)
 [![All Contributors](https://img.shields.io/badge/all_contributors-21-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
@@ -18,8 +19,6 @@ CLI for [`prettier-eslint`][prettier-eslint]
 [![Watch on GitHub][github-watch-badge]][github-watch]
 [![Star on GitHub][github-star-badge]][github-star]
 [![Tweet][twitter-badge]][twitter]
-
-<a href="https://app.codesponsor.io/link/PKGFLnhDiFvsUA5P4kAXfiPs/prettier/prettier-eslint-cli" rel="nofollow"><img src="https://app.codesponsor.io/embed/PKGFLnhDiFvsUA5P4kAXfiPs/prettier/prettier-eslint-cli.svg" style="width: 888px; height: 68px;" alt="Sponsor" /></a>
 
 ## The problem
 
@@ -299,8 +298,8 @@ MIT
 [yarn]: https://yarnpkg.com/
 [npm]: https://www.npmjs.com/
 [node]: https://nodejs.org
-[build-badge]: https://img.shields.io/travis/prettier/prettier-eslint-cli.svg?style=flat-square
-[build]: https://travis-ci.org/prettier/prettier-eslint-cli
+[build-badge]: https://img.shields.io/github/workflow/status/prettier/prettier-eslint-cli/CI?style=flat-square
+[build]: https://github.com/prettier/prettier-eslint-cli/actions/workflows/ci.yml
 [coverage-badge]: https://img.shields.io/codecov/c/github/prettier/prettier-eslint-cli.svg?style=flat-square
 [coverage]: https://codecov.io/github/prettier/prettier-eslint-cli
 [version-badge]: https://img.shields.io/npm/v/prettier-eslint-cli.svg?style=flat-square


### PR DESCRIPTION
BREAKING CHANGE: bump all upgradable (dev)Dependencies except pure ESM

close #436

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Please view https://github.com/prettier/prettier-eslint-cli/pull/437 for more details.

<!-- Why are these changes necessary? -->

**Why**:

This PR is only a workaround to cut a major release for stupid `semantic-release`, see also https://github.com/prettier/prettier-eslint-cli/pull/438#issuecomment-1213593574 and #439

<!-- How were these changes implemented? -->

**How**:

`BREAKING CHANGE:` token must be in the footer of the commit (which is stupid again)

<!-- feel free to add additional comments -->

```log
[09:47:40] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/github"
[09:47:40] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication
[09:47:41] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/github"
[09:47:41] [semantic-release] › ℹ  Found git tag v6.0.1 associated with version 6.0.1 on branch master
[09:47:41] [semantic-release] › ℹ  Found 3 commits since last release
[09:47:41] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[09:47:41] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: docs: cleanup build and sponsors badges

BREAKING CHANGE: bump all upgradable (dev)Dependencies except pure ESM
[09:47:41] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is major
[09:47:41] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 3 commits complete: major release
[09:47:41] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[09:47:41] [semantic-release] › ℹ  The next release version is 7.0.0
[09:47:41] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[09:47:41] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[09:47:41] [semantic-release] › ⚠  Skip step "prepare" of plugin "@semantic-release/npm" in dry-run mode
[09:47:41] [semantic-release] › ⚠  Skip v7.0.0 tag creation in dry-run mode
[09:47:41] [semantic-release] › ⚠  Skip step "publish" of plugin "@semantic-release/npm" in dry-run mode
[09:47:41] [semantic-release] › ⚠  Skip step "publish" of plugin "@semantic-release/github" in dry-run mode
[09:47:41] [semantic-release] › ⚠  Skip step "success" of plugin "@semantic-release/github" in dry-run mode
[09:47:41] [semantic-release] › ✔  Published release 7.0.0 on default channel
[09:47:41] [semantic-release] › ℹ  Release note for version 7.0.0:
# 7.0.0 (https://github.com/prettier/prettier-eslint-cli/compare/v6.0.1...v7.0.0) (2022-08-13)

### Documentation

    * cleanup build and sponsors badges (2fb772a (https://github.com/prettier/prettier-eslint-cli/commit/2fb772a7d0b8257edc81773fc09a7e40da6a5ad0))

### BREAKING CHANGES

    * bump all upgradable (dev)Dependencies except pure ESM
```

I tried it locally, it seems being working now!
