### PR TITLE
fix(deps): migrate `messageformat` to `@messageformat/core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     }
   },
   "dependencies": {
+    "@messageformat/core": "^3.0.1",
     "@prettier/eslint": "npm:prettier-eslint@^15.0.1",
     "arrify": "^2.0.1",
     "boolify": "^1.0.1",
@@ -50,7 +51,6 @@
     "indent-string": "^4.0.0",
     "lodash.memoize": "^4.1.2",
     "loglevel-colored-level-prefix": "^1.0.0",
-    "@messageformat/core": "^3.0.1",
     "rxjs": "^7.5.6",
     "yargs": "^13.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "indent-string": "^4.0.0",
     "lodash.memoize": "^4.1.2",
     "loglevel-colored-level-prefix": "^1.0.0",
-    "messageformat": "^2.3.0",
+    "@messageformat/core": "^3.0.1",
     "rxjs": "^7.5.6",
     "yargs": "^13.1.1"
   },

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,4 +1,4 @@
-import MessageFormat from 'messageformat';
+import MessageFormat from '@messageformat/core';
 
 const mf = new MessageFormat('en');
 

--- a/test/tests/__snapshots__/cli.spec.js.snap
+++ b/test/tests/__snapshots__/cli.spec.js.snap
@@ -17,6 +17,10 @@ Object {
 `;
 
 exports[`prettier-eslint test/fixtures/example*.js --write --no-eslint-ignore --no-prettier-ignore: stdout: prettier-eslint test/fixtures/example*.js --write --no-eslint-ignore --no-prettier-ignore 1`] = `
-"success formatting 2 files with prettier-eslint
+"can't resolve reference #/definitions/directiveConfigSchema from id #
+can't resolve reference #/definitions/directiveConfigSchema from id #
+can't resolve reference #/definitions/directiveConfigSchema from id #
+can't resolve reference #/definitions/directiveConfigSchema from id #
+success formatting 2 files with prettier-eslint
 "
 `;


### PR DESCRIPTION
Package: [messageformat](https://www.npmjs.com/package/messageformat/v/2.3.0) has recently been renamed as '@messageformat/core`

![pnpm notice](https://user-images.githubusercontent.com/53819558/185779213-b1545f95-dd1c-43c3-9c21-e74f4f16481d.png)

My pnpm is noticing me for this change. If you don't mind, can you merge this PR? This way I can freely use `prettier-eslint-cli` in my projects.
